### PR TITLE
Force emit min value when input has incorrect value

### DIFF
--- a/projects/ng-number-picker/src/lib/number-picker.component.ts
+++ b/projects/ng-number-picker/src/lib/number-picker.component.ts
@@ -142,9 +142,7 @@ export class NumberPickerComponent implements OnInit {
     } else if (this.value < this.min) {
       this.value = this.min;
     }
-    if (this.parseVal(this.value)) {
-      this.valueChange.emit(this.value);
-    }
+    this.valueChange.emit(this.parseVal(this.value) ? this.value : this.min);
   }
 
   onDecrease(event: MouseEvent | MouseWheelEvent | KeyboardEvent) {


### PR DESCRIPTION
Hello Wajdi. Let me explain a problem.
Previously you can put characters for example: '.' , '-' in input, and a value is not changed by default to minimum value. The solution from above is resolving this problem.

Why onChange is not firing? Because parseFloat in parseVal() returns NaN and throw "silent" exception

I'm open to suggestions